### PR TITLE
fixed kc0 function so when matching is false it returns an Mij

### DIFF
--- a/R/kc0.R
+++ b/R/kc0.R
@@ -20,7 +20,7 @@
 
 Kc0<-function(dos,inb=FALSE,matching=FALSE){
   if(!matching){
-    tmp<-hierfstat::matching(dos)
+    Mij<-hierfstat::matching(dos)
     }
   else Mij<-dos
   MT<-mean(Mij)


### PR DESCRIPTION
Hi Jerome

I was just running the markdown files that Bruce will use in his course in NZ and came across an error in one of your functions k0C. When dosage was false it wasn't returning an Mij.
cheers, Linley